### PR TITLE
add command to purge ungrouped

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "originHash" : "9950485740236d6039e86c49e115d93daab6dcf581e6462e90e41e64ffeb67f0",
   "pins" : [
     {
+      "identity" : "appstoreconnect-swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AvdLee/appstoreconnect-swift-sdk.git",
+      "state" : {
+        "revision" : "3c71b2bfa08c54cff86e2ed70f1e39a239396ea3",
+        "version" : "4.1.1"
+      }
+    },
+    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",

--- a/Sources/TestflightManager/Commands/RemoveUngroupedCommand.swift
+++ b/Sources/TestflightManager/Commands/RemoveUngroupedCommand.swift
@@ -1,0 +1,317 @@
+import AppStoreConnect_Swift_SDK
+import ArgumentParser
+import Foundation
+
+struct RemoveUngrouped: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "remove-ungrouped",
+    abstract: "Remove beta testers that are not assigned to any beta group."
+  )
+
+  enum OutputFormat: String, ExpressibleByArgument {
+    case text
+    case csv
+  }
+
+  @Option(
+    name: [.customLong("app-id")],
+    help: "Identifier of the app."
+  )
+  var appID: String?
+
+  @Flag(
+    name: [.customLong("dry-run")],
+    help: "List ungrouped testers without removing them."
+  )
+  var dryRun: Bool = false
+
+  @Flag(
+    name: [.customLong("interactive"), .short],
+    help: "Prompt to select options when not provided."
+  )
+  var interactive: Bool = false
+
+  @Option(
+    name: [.customLong("output-path")],
+    help: "Write ungrouped tester details to the specified file instead of listing all entries."
+  )
+  var outputPath: String?
+
+  @Option(
+    name: [.customLong("output-format")],
+    help: "Output file format (text or csv)."
+  )
+  var outputFormat: OutputFormat = .text
+
+  func run() async throws {
+    let environment = await RemoveUngroupedEnvironmentProvider.shared.current()
+
+    do {
+      guard let credentials = try environment.loadCredentials() else {
+        throw CLIError.credentialsNotFound(
+          "No saved credentials. Run 'TestFlightManager login' before removing ungrouped testers."
+        )
+      }
+
+      let context = try await resolveContext(using: environment, credentials: credentials)
+
+      // Fetch all app-level testers
+      let allTesters = try await environment.fetchAppTesters(credentials, context.appID)
+      guard !allTesters.isEmpty else {
+        environment.print("No testers found for app \(context.appID).")
+        return
+      }
+
+      // Fetch all beta groups for the app
+      let betaGroups = try await environment.fetchBetaGroupsForApp(credentials, context.appID)
+
+      // Fetch testers in each beta group and collect their IDs
+      var groupedTesterIDs = Set<String>()
+      for group in betaGroups {
+        let groupTesters = try await environment.fetchBetaGroupTesters(credentials, group.id)
+        groupedTesterIDs.formUnion(groupTesters.map { $0.id })
+      }
+
+      // Find testers that are not in any group
+      let ungroupedTesters = allTesters.filter { !groupedTesterIDs.contains($0.id) }
+
+      guard !ungroupedTesters.isEmpty else {
+        environment.print("No ungrouped testers found for app \(context.appID).")
+        return
+      }
+
+      environment.print(
+        "Found \(ungroupedTesters.count) ungrouped tester(s) not assigned to any beta group:"
+      )
+
+      let sortedUngrouped = ungroupedTesters.sorted { lhs, rhs in
+        displayName(for: lhs).localizedCaseInsensitiveCompare(displayName(for: rhs))
+          == .orderedAscending
+      }
+
+      if let path = context.outputPath {
+        try writeUngroupedTesters(
+          sortedUngrouped,
+          format: outputFormat,
+          path: path
+        )
+        environment.print(
+          "Wrote \(ungroupedTesters.count) ungrouped tester(s) to \(path)."
+        )
+      } else {
+        for tester in sortedUngrouped {
+          environment.print(" - \(displayName(for: tester))")
+        }
+      }
+
+      var shouldDryRun = context.dryRun
+      if context.requiresConfirmation {
+        let confirmed = try environment.confirm("Proceed with removal? (y/N): ")
+        if !confirmed {
+          shouldDryRun = true
+        }
+      }
+
+      if shouldDryRun {
+        environment.print("Dry run summary:")
+        environment.print(" - Total app testers: \(allTesters.count)")
+        environment.print(" - Ungrouped testers: \(ungroupedTesters.count)")
+        environment.print("Dry run: no testers were removed.")
+        return
+      }
+
+      try await environment.removeAppTesters(
+        credentials,
+        context.appID,
+        ungroupedTesters.map { $0.id }
+      )
+
+      environment.print(
+        "Removed \(ungroupedTesters.count) ungrouped tester(s) from app \(context.appID)."
+      )
+    } catch let error as CLIError {
+      throw error
+    } catch let error as APIProvider.Error {
+      throw CLIError.apiFailure(error.localizedDescription)
+    } catch {
+      throw error
+    }
+  }
+
+  private func displayName(for tester: BetaTester) -> String {
+    let attributes = tester.attributes
+    let first = attributes?.firstName?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let last = attributes?.lastName?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let email = attributes?.email?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    let components = [first, last].compactMap { $0 }.filter { !$0.isEmpty }
+    let fullName = components.joined(separator: " ")
+
+    if !fullName.isEmpty, let email, !email.isEmpty {
+      return "\(fullName) <\(email)>"
+    }
+
+    if !fullName.isEmpty {
+      return fullName
+    }
+
+    if let email, !email.isEmpty {
+      return email
+    }
+
+    return tester.id
+  }
+}
+
+extension RemoveUngrouped {
+  fileprivate struct RunContext {
+    let appID: String
+    let dryRun: Bool
+    let requiresConfirmation: Bool
+    let outputPath: String?
+    let outputFormat: OutputFormat
+  }
+
+  fileprivate func resolveContext(using environment: RemoveUngroupedEnvironment, credentials: Credentials)
+    async throws -> RunContext
+  {
+    let shouldPrompt = interactive || appID == nil
+    if !shouldPrompt {
+      guard let appID else {
+        throw CLIError.invalidInput(
+          "App ID is required when interactive mode is disabled."
+        )
+      }
+      return RunContext(
+        appID: appID,
+        dryRun: dryRun,
+        requiresConfirmation: false,
+        outputPath: Self.normalizeOutputPath(outputPath),
+        outputFormat: outputFormat
+      )
+    }
+
+    let apps = try await environment.fetchApps(credentials)
+    guard !apps.isEmpty else {
+      throw CLIError.invalidInput("No apps accessible with the current credentials.")
+    }
+
+    let selectedAppID = try selectAppID(current: appID, apps: apps, environment: environment)
+
+    let confirmDryRun: Bool
+    if let response = try environment.prompt("Dry run? (Y/n): ") {
+      let normalized = response.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+      confirmDryRun = normalized.isEmpty || normalized == "y" || normalized == "yes"
+    } else {
+      confirmDryRun = true
+    }
+
+    return RunContext(
+      appID: selectedAppID,
+      dryRun: confirmDryRun,
+      requiresConfirmation: !confirmDryRun,
+      outputPath: Self.normalizeOutputPath(outputPath),
+      outputFormat: outputFormat
+    )
+  }
+
+  private func selectAppID(
+    current: String?,
+    apps: [App],
+    environment: RemoveUngroupedEnvironment
+  ) throws -> String {
+    if let current {
+      if apps.contains(where: { $0.id == current }) {
+        return current
+      }
+      throw CLIError.invalidInput("App ID \(current) not found in accessible apps.")
+    }
+
+    if apps.count == 1 {
+      return apps[0].id
+    }
+
+    environment.print("Select an app:")
+    for (index, app) in apps.enumerated() {
+      let name = app.attributes?.name ?? "Unknown"
+      let bundleID = app.attributes?.bundleID ?? "N/A"
+      environment.print("\(index + 1). \(name) (\(bundleID))")
+    }
+
+    guard let input = try environment.prompt("Enter app number: "),
+      let selection = Int(input.trimmingCharacters(in: .whitespacesAndNewlines)),
+      selection > 0,
+      selection <= apps.count
+    else {
+      throw CLIError.invalidInput("Invalid app selection.")
+    }
+
+    return apps[selection - 1].id
+  }
+
+  private static func normalizeOutputPath(_ path: String?) -> String? {
+    guard let path else { return nil }
+    let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : (trimmed as NSString).expandingTildeInPath
+  }
+}
+
+extension RemoveUngrouped {
+  private func writeUngroupedTesters(
+    _ testers: [BetaTester],
+    format: OutputFormat,
+    path: String
+  ) throws {
+    let url = URL(fileURLWithPath: path)
+    let directory = url.deletingLastPathComponent()
+
+    if directory.path != "" && directory.path != "." {
+      try FileManager.default.createDirectory(
+        at: directory,
+        withIntermediateDirectories: true
+      )
+    }
+
+    let contents: String
+    switch format {
+    case .text:
+      var lines: [String] = [
+        "Ungrouped testers (not assigned to any beta group)",
+        ""
+      ]
+      lines.append(contentsOf: testers.map { displayName(for: $0) })
+      contents = lines.joined(separator: "\n") + "\n"
+    case .csv:
+      var rows: [String] = [
+        "tester_id,first_name,last_name,email,state"
+      ]
+      for tester in testers {
+        let attrs = tester.attributes
+        let first = attrs?.firstName ?? ""
+        let last = attrs?.lastName ?? ""
+        let email = attrs?.email ?? ""
+        let state = attrs?.state?.rawValue ?? ""
+        let columns = [
+          escapeCSV(tester.id),
+          escapeCSV(first),
+          escapeCSV(last),
+          escapeCSV(email),
+          escapeCSV(state)
+        ]
+        rows.append(columns.joined(separator: ","))
+      }
+      contents = rows.joined(separator: "\n") + "\n"
+    }
+
+    try contents.write(to: url, atomically: true, encoding: .utf8)
+  }
+
+  private func escapeCSV(_ value: String) -> String {
+    let needsQuotes = value.contains(",") || value.contains("\"") || value.contains("\n")
+    if needsQuotes {
+      let escaped = value.replacingOccurrences(of: "\"", with: "\"\"")
+      return "\"\(escaped)\""
+    }
+    return value
+  }
+}

--- a/Sources/TestflightManager/Environments/RemoveUngroupedEnvironment.swift
+++ b/Sources/TestflightManager/Environments/RemoveUngroupedEnvironment.swift
@@ -1,0 +1,216 @@
+import AppStoreConnect_Swift_SDK
+import Foundation
+
+struct RemoveUngroupedEnvironment: @unchecked Sendable {
+  var loadCredentials: () throws -> Credentials?
+  var fetchApps: (Credentials) async throws -> [App]
+  var fetchBetaGroupsForApp: (Credentials, String) async throws -> [BetaGroup]
+  var fetchAppTesters: (Credentials, String) async throws -> [BetaTester]
+  var fetchBetaGroupTesters: (Credentials, String) async throws -> [BetaTester]
+  var removeAppTesters: (Credentials, String, [String]) async throws -> Void
+  var print: (String) -> Void
+  var prompt: (String) throws -> String?
+  var confirm: (String) throws -> Bool
+
+  static let live = RemoveUngroupedEnvironment(
+    loadCredentials: {
+      let store = CredentialsStore()
+      return try store.load()
+    },
+    fetchApps: { credentials in
+      let provider = try makeProvider(from: credentials)
+      let request = APIEndpoint
+        .v1
+        .apps
+        .get(
+          parameters: .init(
+            sort: [.name],
+            fieldsApps: [.name, .bundleID],
+            limit: 200
+          )
+        )
+
+      var apps: [App] = []
+      for try await page in provider.paged(request) {
+        apps.append(contentsOf: page.data)
+      }
+      return apps
+    },
+    fetchBetaGroupsForApp: { credentials, appID in
+      let provider = try makeProvider(from: credentials)
+      let request = APIEndpoint
+        .v1
+        .apps
+        .id(appID)
+        .betaGroups
+        .get(
+          fieldsBetaGroups: [.name],
+          limit: 200
+        )
+
+      let progressLogger = Logger.stdout
+      let progressTheme = progressLogger.consoleTheme
+      progressLogger.notice(
+        "Fetching beta groups for app "
+          + progressLogger.applying(progressTheme.emphasis, to: appID)
+          + "..."
+      )
+
+      var groups: [BetaGroup] = []
+      for try await page in provider.paged(request) {
+        groups.append(contentsOf: page.data)
+      }
+      
+      let totalLabel = progressLogger.applying(progressTheme.emphasis, to: "\(groups.count)")
+      progressLogger.notice("Found " + totalLabel + " beta group(s).")
+      return groups
+    },
+    fetchAppTesters: { credentials, appID in
+      let provider = try makeProvider(from: credentials)
+      let request = APIEndpoint
+        .v1
+        .betaTesters
+        .get(
+          parameters: .init(
+            filterApps: [appID],
+            fieldsBetaTesters: [.firstName, .lastName, .email, .state],
+            limit: 200
+          )
+        )
+
+      let progressLogger = Logger.stdout
+      let progressTheme = progressLogger.consoleTheme
+      progressLogger.notice(
+        "Fetching all beta testers for app "
+          + progressLogger.applying(progressTheme.emphasis, to: appID)
+          + "..."
+      )
+
+      var testers: [BetaTester] = []
+      var pageIndex = 0
+      var lastReportedCount = 0
+      for try await page in provider.paged(request) {
+        pageIndex += 1
+        testers.append(contentsOf: page.data)
+        let total = testers.count
+        if pageIndex == 1 || total - lastReportedCount >= 500 {
+          let formattedCount = progressLogger.applying(progressTheme.emphasis, to: "\(total)")
+          progressLogger.info("Fetched " + formattedCount + " beta tester(s)...")
+          lastReportedCount = total
+        }
+      }
+      let totalLabel = progressLogger.applying(progressTheme.emphasis, to: "\(testers.count)")
+      progressLogger.notice("Completed fetching " + totalLabel + " beta tester(s).")
+      return testers
+    },
+    fetchBetaGroupTesters: { credentials, groupID in
+      let provider = try makeProvider(from: credentials)
+      let request = APIEndpoint
+        .v1
+        .betaGroups
+        .id(groupID)
+        .betaTesters
+        .get(
+          fieldsBetaTesters: [.email],
+          limit: 200
+        )
+
+      var testers: [BetaTester] = []
+      for try await page in provider.paged(request) {
+        testers.append(contentsOf: page.data)
+      }
+      return testers
+    },
+    removeAppTesters: { credentials, appID, testerIDs in
+      guard !testerIDs.isEmpty else { return }
+
+      let provider = try makeProvider(from: credentials)
+      let progressLogger = Logger.stdout
+      let progressTheme = progressLogger.consoleTheme
+      
+      progressLogger.notice(
+        "Removing "
+          + progressLogger.applying(progressTheme.emphasis, to: "\(testerIDs.count)")
+          + " tester(s) from app..."
+      )
+
+      // The API requires removing testers one at a time or in small batches
+      // We'll batch them in groups of 100 for efficiency
+      let batchSize = 100
+      var removedCount = 0
+      
+      for batchStart in stride(from: 0, to: testerIDs.count, by: batchSize) {
+        let batchEnd = min(batchStart + batchSize, testerIDs.count)
+        let batch = Array(testerIDs[batchStart..<batchEnd])
+        
+        let request = APIEndpoint
+          .v1
+          .apps
+          .id(appID)
+          .relationships
+          .betaTesters
+          .delete(
+            AppBetaTestersLinkagesRequest(
+              data: batch.map { .init(type: .betaTesters, id: $0) }
+            )
+          )
+
+        try await provider.request(request)
+        removedCount += batch.count
+        
+        if testerIDs.count > batchSize {
+          progressLogger.info(
+            "Removed "
+              + progressLogger.applying(progressTheme.emphasis, to: "\(removedCount)")
+              + " of "
+              + progressLogger.applying(progressTheme.emphasis, to: "\(testerIDs.count)")
+              + " tester(s)..."
+          )
+        }
+      }
+      
+      progressLogger.notice(
+        "Successfully removed "
+          + progressLogger.applying(progressTheme.emphasis, to: "\(removedCount)")
+          + " tester(s)."
+      )
+    },
+    print: { message in
+      Logger.stdout.info(message)
+    },
+    prompt: { message in
+      FileHandle.standardOutput.write(Data(message.utf8))
+      return readLine()
+    },
+    confirm: { message in
+      FileHandle.standardOutput.write(Data(message.utf8))
+      let response = readLine()?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+      return response == "y" || response == "yes"
+    }
+  )
+}
+
+extension RemoveUngroupedEnvironment {
+  fileprivate static func makeProvider(from credentials: Credentials) throws -> APIProvider {
+    let configuration = try credentials.apiConfiguration()
+    return APIProvider(configuration: configuration)
+  }
+}
+
+actor RemoveUngroupedEnvironmentProvider {
+  static let shared = RemoveUngroupedEnvironmentProvider()
+
+  private var environment: RemoveUngroupedEnvironment = .live
+
+  func current() -> RemoveUngroupedEnvironment {
+    environment
+  }
+
+  func set(_ environment: RemoveUngroupedEnvironment) {
+    self.environment = environment
+  }
+
+  func reset() {
+    environment = .live
+  }
+}

--- a/Sources/TestflightManager/TestflightManager.swift
+++ b/Sources/TestflightManager/TestflightManager.swift
@@ -4,7 +4,7 @@ import ArgumentParser
 struct TestFlightManager: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     abstract: "CLI tool for managing TestFlight users via App Store Connect.",
-    subcommands: [Login.self, Config.self, Purge.self],
+    subcommands: [Login.self, Config.self, Purge.self, RemoveUngrouped.self],
     defaultSubcommand: Login.self
   )
 }

--- a/Tests/TestflightManagerTests/RemoveUngroupedTests.swift
+++ b/Tests/TestflightManagerTests/RemoveUngroupedTests.swift
@@ -1,0 +1,287 @@
+import AppStoreConnect_Swift_SDK
+import XCTest
+
+@testable import TestFlightManager
+
+final class RemoveUngroupedTests: XCTestCase {
+  private var temporaryFiles: [URL] = []
+
+  override func tearDown() {
+    for fileURL in temporaryFiles {
+      try? FileManager.default.removeItem(at: fileURL)
+    }
+    temporaryFiles.removeAll()
+    super.tearDown()
+  }
+
+  func testRunRemovesUngroupedTesters() async throws {
+    let credentials = try makeCredentials()
+
+    var removedTesterIDs: [String] = []
+    var printedMessages: [String] = []
+
+    let appTesters = [
+      makeTester(id: "grouped1", email: "grouped1@example.com"),
+      makeTester(id: "grouped2", email: "grouped2@example.com"),
+      makeTester(id: "ungrouped1", email: "ungrouped1@example.com"),
+      makeTester(id: "ungrouped2", email: "ungrouped2@example.com"),
+    ]
+
+    let groupTesters = [
+      makeTester(id: "grouped1", email: "grouped1@example.com"),
+      makeTester(id: "grouped2", email: "grouped2@example.com"),
+    ]
+
+    let provider = RemoveUngroupedEnvironmentProvider.shared
+    await provider.set(
+      RemoveUngroupedEnvironment(
+        loadCredentials: { credentials },
+        fetchApps: { _ in
+          XCTFail("fetchApps should not be called when app ID is provided")
+          return []
+        },
+        fetchBetaGroupsForApp: { _, _ in
+          [BetaGroup(type: .betaGroups, id: "group1")]
+        },
+        fetchAppTesters: { _, _ in appTesters },
+        fetchBetaGroupTesters: { _, _ in groupTesters },
+        removeAppTesters: { _, _, ids in removedTesterIDs = ids },
+        print: { printedMessages.append($0) },
+        prompt: { _ in nil },
+        confirm: { _ in true }
+      )
+    )
+    defer { Task { await provider.reset() } }
+
+    let command = try RemoveUngrouped.parse([
+      "--app-id", "app123",
+    ])
+
+    try await command.run()
+
+    XCTAssertEqual(Set(removedTesterIDs), Set(["ungrouped1", "ungrouped2"]))
+    XCTAssertTrue(printedMessages.contains { $0.contains("2 ungrouped tester") })
+    XCTAssertTrue(printedMessages.contains { $0.contains("Removed 2") })
+  }
+
+  func testDryRunDoesNotRemoveTesters() async throws {
+    let credentials = try makeCredentials()
+
+    var removeCallCount = 0
+    var printedMessages: [String] = []
+
+    let appTesters = [makeTester(id: "ungrouped", email: "test@example.com")]
+
+    let provider = RemoveUngroupedEnvironmentProvider.shared
+    await provider.set(
+      RemoveUngroupedEnvironment(
+        loadCredentials: { credentials },
+        fetchApps: { _ in
+          XCTFail("fetchApps should not be called when app ID is provided")
+          return []
+        },
+        fetchBetaGroupsForApp: { _, _ in [] },
+        fetchAppTesters: { _, _ in appTesters },
+        fetchBetaGroupTesters: { _, _ in [] },
+        removeAppTesters: { _, _, _ in removeCallCount += 1 },
+        print: { printedMessages.append($0) },
+        prompt: { _ in nil },
+        confirm: { _ in true }
+      )
+    )
+    defer { Task { await provider.reset() } }
+
+    let command = try RemoveUngrouped.parse([
+      "--app-id", "app123",
+      "--dry-run",
+    ])
+
+    try await command.run()
+
+    XCTAssertEqual(removeCallCount, 0)
+    XCTAssertTrue(printedMessages.contains("Dry run summary:"))
+    XCTAssertTrue(printedMessages.contains(" - Total app testers: 1"))
+    XCTAssertTrue(printedMessages.contains(" - Ungrouped testers: 1"))
+    XCTAssertTrue(printedMessages.contains("Dry run: no testers were removed."))
+  }
+
+  func testDryRunWritesUngroupedTestersToFileWhenRequested() async throws {
+    let credentials = try makeCredentials()
+
+    var printedMessages: [String] = []
+    let appTesters = [
+      makeTester(id: "ungrouped", email: "ungrouped@example.com")
+    ]
+
+    let outputURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString)
+      .appendingPathExtension("csv")
+    temporaryFiles.append(outputURL)
+
+    let provider = RemoveUngroupedEnvironmentProvider.shared
+    await provider.set(
+      RemoveUngroupedEnvironment(
+        loadCredentials: { credentials },
+        fetchApps: { _ in [] },
+        fetchBetaGroupsForApp: { _, _ in [] },
+        fetchAppTesters: { _, _ in appTesters },
+        fetchBetaGroupTesters: { _, _ in [] },
+        removeAppTesters: { _, _, _ in XCTFail("removeAppTesters should not be called") },
+        print: { printedMessages.append($0) },
+        prompt: { _ in nil },
+        confirm: { _ in true }
+      )
+    )
+    defer { Task { await provider.reset() } }
+
+    let command = try RemoveUngrouped.parse([
+      "--app-id", "app123",
+      "--dry-run",
+      "--output-path", outputURL.path,
+      "--output-format", "csv"
+    ])
+
+    try await command.run()
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: outputURL.path))
+    let contents = try String(contentsOf: outputURL)
+    XCTAssertTrue(contents.contains("tester_id"))
+    XCTAssertTrue(contents.contains("ungrouped"))
+    XCTAssertFalse(printedMessages.contains(where: { $0.contains("ungrouped@example.com") }))
+    XCTAssertTrue(
+      printedMessages.contains {
+        $0.contains(outputURL.lastPathComponent)
+      }
+    )
+  }
+
+  func testRunThrowsWhenCredentialsMissing() async {
+    let provider = RemoveUngroupedEnvironmentProvider.shared
+    await provider.set(
+      RemoveUngroupedEnvironment(
+        loadCredentials: { nil },
+        fetchApps: { _ in [] },
+        fetchBetaGroupsForApp: { _, _ in [] },
+        fetchAppTesters: { _, _ in
+          XCTFail("fetchAppTesters should not be called when credentials are missing")
+          return []
+        },
+        fetchBetaGroupTesters: { _, _ in [] },
+        removeAppTesters: { _, _, _ in },
+        print: { _ in },
+        prompt: { _ in nil },
+        confirm: { _ in false }
+      )
+    )
+    defer { Task { await provider.reset() } }
+
+    do {
+      let command = try RemoveUngrouped.parse([
+        "--app-id", "app123",
+      ])
+      try await command.run()
+      XCTFail("Expected command to throw when credentials are missing")
+    } catch let error as CLIError {
+      if case .credentialsNotFound(let message) = error {
+        XCTAssertTrue(message.contains("login"))
+      } else {
+        XCTFail("Unexpected CLIError: \(error)")
+      }
+    } catch {
+      XCTFail("Unexpected error thrown: \(error)")
+    }
+  }
+
+  func testRunHandlesNoUngroupedTesters() async throws {
+    let credentials = try makeCredentials()
+
+    var printedMessages: [String] = []
+
+    let appTesters = [
+      makeTester(id: "grouped", email: "grouped@example.com")
+    ]
+
+    let groupTesters = [
+      makeTester(id: "grouped", email: "grouped@example.com")
+    ]
+
+    let provider = RemoveUngroupedEnvironmentProvider.shared
+    await provider.set(
+      RemoveUngroupedEnvironment(
+        loadCredentials: { credentials },
+        fetchApps: { _ in [] },
+        fetchBetaGroupsForApp: { _, _ in
+          [BetaGroup(type: .betaGroups, id: "group1")]
+        },
+        fetchAppTesters: { _, _ in appTesters },
+        fetchBetaGroupTesters: { _, _ in groupTesters },
+        removeAppTesters: { _, _, _ in XCTFail("removeAppTesters should not be called") },
+        print: { printedMessages.append($0) },
+        prompt: { _ in nil },
+        confirm: { _ in true }
+      )
+    )
+    defer { Task { await provider.reset() } }
+
+    let command = try RemoveUngrouped.parse([
+      "--app-id", "app123",
+    ])
+
+    try await command.run()
+
+    XCTAssertTrue(printedMessages.contains { $0.contains("No ungrouped testers found") })
+  }
+
+  func testRunHandlesNoAppTesters() async throws {
+    let credentials = try makeCredentials()
+
+    var printedMessages: [String] = []
+
+    let provider = RemoveUngroupedEnvironmentProvider.shared
+    await provider.set(
+      RemoveUngroupedEnvironment(
+        loadCredentials: { credentials },
+        fetchApps: { _ in [] },
+        fetchBetaGroupsForApp: { _, _ in [] },
+        fetchAppTesters: { _, _ in [] },
+        fetchBetaGroupTesters: { _, _ in [] },
+        removeAppTesters: { _, _, _ in XCTFail("removeAppTesters should not be called") },
+        print: { printedMessages.append($0) },
+        prompt: { _ in nil },
+        confirm: { _ in true }
+      )
+    )
+    defer { Task { await provider.reset() } }
+
+    let command = try RemoveUngrouped.parse([
+      "--app-id", "app123",
+    ])
+
+    try await command.run()
+
+    XCTAssertTrue(printedMessages.contains { $0.contains("No testers found for app") })
+  }
+
+  private func makeCredentials() throws -> Credentials {
+    let keyURL = try makeTemporaryKeyFile()
+    return try Credentials(issuerID: "ISSUER", keyID: "KEY", privateKeyPath: keyURL.path)
+  }
+
+  private func makeTemporaryKeyFile() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString)
+      .appendingPathExtension("p8")
+    let data = Data("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n".utf8)
+    FileManager.default.createFile(atPath: url.path, contents: data)
+    temporaryFiles.append(url)
+    return url
+  }
+
+  private func makeTester(id: String, email: String) -> BetaTester {
+    BetaTester(
+      type: .betaTesters,
+      id: id,
+      attributes: .init(email: email)
+    )
+  }
+}


### PR DESCRIPTION
Adds command to purge ungrouped users.

There is a problem where removing from a group still works against your limit for testers. this removes them totally as a tester so it does not impact limit

